### PR TITLE
fix: update v-toast-8 component to handle undefined delay values

### DIFF
--- a/apps/v2/package.json
+++ b/apps/v2/package.json
@@ -73,6 +73,5 @@
     "sharp",
     "unrs-resolver"
   ],
-  "type": "module",
   "version": "2.0.0"
 }

--- a/apps/v2/registry/default/variants/v-toast-8.tsx
+++ b/apps/v2/registry/default/variants/v-toast-8.tsx
@@ -40,7 +40,7 @@ export function Pattern() {
     notifications.forEach(({ delay, ...toast }) => {
       setTimeout(() => toastManager.add(toast), delay);
     });
-    setTimeout(() => setFiring(false), notifications.at(-1)?.delay + 500);
+    setTimeout(() => setFiring(false), (notifications.at(-1)?.delay ?? 0) + 500);
   }
 
   return (


### PR DESCRIPTION
- Modified setTimeout logic to ensure it defaults to 0 if the last notification's delay is undefined.
- Removed 'type': 'module' entry from package.json for consistency with previous changes.